### PR TITLE
chore: remove scripts/bump-dev.sh from .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,10 +11,3 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]
-  - repo: local
-    hooks:
-      - id: set-version
-        language: script
-        name: sets __version__ in viv.py
-        entry: ./scripts/bump-dev.sh
-        files: viv.py$


### PR DESCRIPTION
The script was removed in 08cf8ee7d1fe1afd55c1a488dfeb489a964b7d60

Fixes #10